### PR TITLE
Change Plane "height" to "depth"

### DIFF
--- a/Assets/Scripts/Components/PlanePrimitive.cs
+++ b/Assets/Scripts/Components/PlanePrimitive.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 public class PlanePrimitive : PrimitiveAdapter 
 {
     public float width = 10f;
-    public float height = 10f;
+    public float depth = 10f;
     public bool finite = true;
 
     protected override PrimitiveType PrimitiveType
@@ -16,7 +16,7 @@ public class PlanePrimitive : PrimitiveAdapter
 
     protected override Matrix4x4 GetLocalSpaceMatrixByParameters()
     {
-        Vector3 scale = new Vector3(width / 10f, 1f, height / 10f);
+        Vector3 scale = new Vector3(width / 10f, 1f, depth / 10f);
         
         if (!finite)
             scale = new Vector3(5000f, 1f, 5000f);

--- a/Assets/Scripts/Core/Scene/Shape/SSDPlaneShape.cs
+++ b/Assets/Scripts/Core/Scene/Shape/SSDPlaneShape.cs
@@ -7,7 +7,7 @@ namespace SimpleSceneDescription
     {
         protected bool finite = true;
         protected float width = 10f;
-        protected float height = 10f;
+        protected float depth = 10f;
 
         protected override ShapeType ShapeType { get { return ShapeType.Plane; } }
 
@@ -18,15 +18,18 @@ namespace SimpleSceneDescription
             this.Material = plane.material;
             this.finite = plane.finite;
             this.width = plane.width;
-            this.height = plane.height;
+            this.depth = plane.depth;
         }
 
         public override void OnToJSON(Hashtable ht)
         {
             base.OnToJSON(ht);
             ht["finite"] = finite;
-            ht["width"] = width;
-            ht["height"] = height;
+            if (finite)
+            {
+                ht["width"] = width;
+                ht["depth"] = depth;
+            }
         }
     }
 }


### PR DESCRIPTION
Changed the Plane's "height" (Y axis) property to "depth" (Z axis), for consistency with the Cube primitive.  Also, only include these values in JSON if the plane is finite.
