### PR TITLE
Fixed normal map texture

### DIFF
--- a/Assets/Scripts/Core/Asset/SSDMaterial.cs
+++ b/Assets/Scripts/Core/Asset/SSDMaterial.cs
@@ -186,6 +186,10 @@ namespace SimpleSceneDescription
             foreach(SingleChannel channel in singleChannels.Values)
                 if (channel.texture)
                     objects.Add(channel.texture);
+
+            foreach (TextureChannel channel in textureChannels.Values)
+                if (channel.texture)
+                    objects.Add (channel.texture);
         }
         
         public override void OnToJSON(Hashtable ht)


### PR DESCRIPTION
Normal maps were not saved to SSD files because they were not added to the objec list in `OnGetDependencies()`. This diff fixes that.
